### PR TITLE
Refactor for CMake linux and cross-platform builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ exploration/nsight_profiler.cfg
 
 # blender
 *.blend1
+build/
+out/
+.cache/
+compile_commands.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "C++ Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/exploration",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "build"
+        } 
+
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "cmake",
+			"label": "build",
+			"command": "build",
+			"targets": [
+				"exploration"
+			],
+			"group": "build",
+			"problemMatcher": [],
+			"detail": "CMake template build task"
+		}
+	]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,114 @@
+cmake_minimum_required(VERSION 3.16)
+project(WorldsOfWhite LANGUAGES C CXX)
+
+# C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Dependencies
+find_package(OpenGL REQUIRED)
+find_package(JPEG REQUIRED)
+find_package(Bullet REQUIRED) # Prefer config package, fallback to Find module
+
+
+# GLFW - prefer CMake config, fallback to pkg-config
+find_package(glfw3 3.3 QUIET)
+if(NOT glfw3_FOUND)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(GLFW3 REQUIRED IMPORTED_TARGET glfw3)
+endif()
+
+# Sources (mirrors the Visual Studio project)
+set(EXPLORATION_SOURCES
+  exploration/main.cpp
+  exploration/InputManager.cpp
+  exploration/utilities/ring.cpp
+  exploration/libraries/glad/src/glad.c
+  exploration/logging/LoggingManager.cpp
+  exploration/logging/SourceLogger.cpp
+  exploration/logging/loggers/FileLogger.cpp
+  exploration/logging/loggers/StreamLogger.cpp
+  exploration/graphics/shader.cpp
+  exploration/graphics/program.cpp
+  exploration/graphics/texture.cpp
+  exploration/graphics/framebuffer.cpp
+  exploration/graphics/joint.cpp
+  exploration/graphics/jointPose.cpp
+  exploration/graphics/programs/ScreenProgram.cpp
+  exploration/graphics/programs/DepthProgram.cpp
+  exploration/graphics/programs/DebugProgram.cpp
+  exploration/graphics/programs/LineProgram.cpp
+  exploration/Model.cpp
+  exploration/entities/AnimatedEntity.cpp
+  exploration/entities/PlayerEntity.cpp
+  exploration/entities/DecorationEntity.cpp
+  exploration/entities/Entity.cpp
+  exploration/entities/PhysicsEntity.cpp
+  exploration/entities/SpiritEntity.cpp
+  exploration/entities/SmashEffectEntity.cpp
+  exploration/entities/TerrainEntity.cpp
+  exploration/cameras/FollowCamera.cpp
+  exploration/cameras/FreeCamera.cpp
+  exploration/cameras/TrackCamera.cpp
+  exploration/cameras/IdleCamera.cpp
+)
+
+add_executable(exploration ${EXPLORATION_SOURCES})
+
+# Include directories: project headers + vendored header-only libs
+# (GLFW include dir comes from the package, not the vendored headers in this repo)
+target_include_directories(exploration PRIVATE
+  build
+
+  exploration
+  exploration/libraries/glad/include
+  exploration/libraries/glm/include
+  exploration/libraries/cimg/include
+  
+  ${BULLET_INCLUDE_DIRS}
+)
+
+# CImg setup: don't pull X11 display backends; enable JPEG loader
+# This avoids linking to X11 while still allowing texture loading from JPEG.
+target_compile_definitions(exploration PRIVATE cimg_display=0 cimg_use_jpeg)
+
+# Link libraries
+if(glfw3_FOUND)
+  # Different distros export different target names; support common ones
+  if(TARGET glfw)
+    target_link_libraries(exploration PRIVATE glfw)
+  elseif(TARGET glfw3::glfw)
+    target_link_libraries(exploration PRIVATE glfw3::glfw)
+  elseif(TARGET GLFW::GLFW)
+    target_link_libraries(exploration PRIVATE GLFW::GLFW)
+  else()
+    message(FATAL_ERROR "glfw3 was found but no known CMake target is available.")
+  endif()
+else()
+  target_link_libraries(exploration PRIVATE PkgConfig::GLFW3)
+endif()
+
+# OpenGL, JPEG, Bullet
+# Prefer Bullet imported target if available, else fall back to variables
+if(TARGET Bullet::Bullet)
+  target_link_libraries(exploration PRIVATE OpenGL::GL JPEG::JPEG Bullet::Bullet)
+elseif(DEFINED BULLET_LIBRARIES)
+  target_link_libraries(exploration PRIVATE OpenGL::GL JPEG::JPEG ${BULLET_LIBRARIES})
+else()
+  # Last resort: try common Bullet components
+  target_link_libraries(exploration PRIVATE OpenGL::GL JPEG::JPEG BulletCollision BulletDynamics LinearMath)
+endif()
+
+# On some systems Bullet does not provide imported targets; ensure PIC where needed
+set_property(TARGET exploration PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+# Convenience run target to run from build/ with asset symlinks
+add_custom_target(run
+  COMMAND ${CMAKE_COMMAND} -E env zsh ${CMAKE_SOURCE_DIR}/scripts/run_from_build.zsh ${CMAKE_BINARY_DIR}
+  DEPENDS exploration
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  USES_TERMINAL
+)
+
+# Install rule (optional)
+install(TARGETS exploration RUNTIME DESTINATION bin)

--- a/exploration/EntityType.h
+++ b/exploration/EntityType.h
@@ -1,9 +1,9 @@
 #ifndef WILT_ENTITYTYPE_H
 #define WILT_ENTITYTYPE_H
 
-#include <chrono>
 #include <filesystem>
 #include <iostream>
+#include <fstream>
 
 class Model;
 class Entity;

--- a/exploration/InputManager.cpp
+++ b/exploration/InputManager.cpp
@@ -31,18 +31,26 @@ void InputManager::update()
   }
 
   { // buttons
-    auto buttonsCount = 0;
-    auto buttonsRaw = glfwGetJoystickButtons(joystickId, &buttonsCount);
-
     buttonsPrevious = std::move(buttonsCurrent);
-    buttonsCurrent = std::vector<unsigned char>(buttonsRaw, buttonsRaw + buttonsCount); // TODO: reuse vector space
+    buttonsCurrent.clear();
+    
+    if (joystickId >= GLFW_JOYSTICK_1 && glfwJoystickPresent(joystickId))
+    {
+      auto buttonsCount = 0;
+      auto buttonsRaw = glfwGetJoystickButtons(joystickId, &buttonsCount);
+      buttonsCurrent = std::vector<unsigned char>(buttonsRaw, buttonsRaw + buttonsCount); // TODO: reuse vector space
+    }
   }
 
   { // axes
-    auto axesCount = 0;
-    auto axesRaw = glfwGetJoystickAxes(joystickId, &axesCount);
-
-    axes = std::vector<float>(axesRaw, axesRaw + axesCount); // TODO: reuse vector space
+    axes.clear();
+    
+    if (joystickId >= GLFW_JOYSTICK_1 && glfwJoystickPresent(joystickId))
+    {
+      auto axesCount = 0;
+      auto axesRaw = glfwGetJoystickAxes(joystickId, &axesCount);
+      axes = std::vector<float>(axesRaw, axesRaw + axesCount); // TODO: reuse vector space
+    }
   }
 }
 
@@ -87,6 +95,9 @@ bool InputManager::isButtonReleased(int button)
 
 float InputManager::getAxis(int axis)
 {
+  if (axis < 0 || axis >= axes.size())
+    return 0.0f;
+    
   return axes[axis];
 }
 

--- a/exploration/Model.cpp
+++ b/exploration/Model.cpp
@@ -1,4 +1,4 @@
-#include "model.h"
+#include "Model.h"
 
 #include <fstream>
 

--- a/exploration/cameras/IdleCamera.cpp
+++ b/exploration/cameras/IdleCamera.cpp
@@ -15,7 +15,7 @@ const auto CAMERA_HEIGHT_ANGLE = 0.5f;
 const auto CAMERA_IDLE_TIME = std::chrono::seconds(3);
 const auto CAMERA_IDLE_RATE = 0.001f;
 
-glm::vec3 calcPosition(float xangle, float yangle, float distance);
+static glm::vec3 calcPosition(float xangle, float yangle, float distance);
 
 IdleCamera::IdleCamera(Entity** entity)
   : entity_{ entity }

--- a/exploration/entities/Entity.h
+++ b/exploration/entities/Entity.h
@@ -1,12 +1,11 @@
 #ifndef WILT_ENTITY_H
 #define WILT_ENTITY_H
 
-#include <vector>
 
 #include <glm/glm.hpp>
 
 #include "../EntitySpawnInfo.h"
-#include "../GameState.h"
+#include "GameState.h"
 
 class IAnimator;
 class Model;
@@ -32,7 +31,7 @@ public:
 
 }; // class Entity
 
-#include "../model.h"
+#include "Model.h"
 #include "../graphics/programs/DepthProgram.h"
 #include "../graphics/programs/LineProgram.h"
 #include "../graphics/programs/DebugProgram.h"

--- a/exploration/graphics/programs/LineProgram.cpp
+++ b/exploration/graphics/programs/LineProgram.cpp
@@ -25,8 +25,11 @@ void LineProgram::use()
 {
   Program::use();
 
-  glUniform3fv(locationBurstLocations, burstLocations.size(), &burstLocations[0][0]);
-  glUniform1fv(locationBurstRanges, burstRanges.size(), &burstRanges[0]);
+  if (!burstLocations.empty())
+  {
+    glUniform3fv(locationBurstLocations, burstLocations.size(), &burstLocations[0][0]);
+    glUniform1fv(locationBurstRanges, burstRanges.size(), &burstRanges[0]);
+  }
   glUniform1ui(locationBurstCount, burstLocations.size());
 }
 

--- a/exploration/libraries/cimg/include/cimg/cimg.h
+++ b/exploration/libraries/cimg/include/cimg/cimg.h
@@ -445,7 +445,7 @@ extern "C" {
 // (see methods 'CImg<T>::{load,save}_jpeg()').
 #ifdef cimg_use_jpeg
 extern "C" {
-#include <libjpeg/jpeglib.h>
+#include <jpeglib.h>
 #include "setjmp.h"
 }
 #endif

--- a/exploration/logging/loggers/StreamLogger.cpp
+++ b/exploration/logging/loggers/StreamLogger.cpp
@@ -19,8 +19,7 @@ inline bool StreamLogger::log(LoggingLevel level, const char* source, const char
 
   std::time_t s = ns / 1000000000;
   int ms = (ns % 1000000000) / 1000000;
-  std::tm time;
-  gmtime_s(&time, &s);
+  std::tm time = *std::gmtime(&s);
 
   // YYYY-MM-DDTHH:MM:SS [?] Source: Message
   auto fill = _stream.fill();

--- a/exploration/shaders/depth.frag.glsl
+++ b/exploration/shaders/depth.frag.glsl
@@ -1,5 +1,7 @@
 #version 420 core
 
+layout(location = 0) out vec4 FragColor;
+
 in vec3  norml_geom_out;
 in float order_geom_out;
 in vec4  world_geom_out;
@@ -348,5 +350,5 @@ void main()
 
   float val = getBanding(rfpos.yxz, zoom); // TODO: swap x and y elsewhere
 
-  gl_FragColor = vec4(val, val, val, 1.0);
+  FragColor = vec4(val, val, val, 1.0);
 }

--- a/exploration/shaders/line.geom.glsl
+++ b/exploration/shaders/line.geom.glsl
@@ -23,13 +23,25 @@ uniform uint  burst_count;
 // any manipulations, then put it back into the projection space. This might be 
 // supplied later through a unifrom variable.
 
-const mat4 to_screen_space = mat4(
-	1, 0,       0, 0,
-	0, 1/ratio, 0, 0,
-	0, 0,       1, 0,
-	0, 0,       0, 1
-);
-const mat4 from_screen_space = inverse(to_screen_space);
+mat4 to_screen_space()
+{
+	return mat4(
+		1, 0,       0, 0,
+		0, 1/ratio, 0, 0,
+		0, 0,       1, 0,
+		0, 0,       0, 1
+	);
+}
+mat4 from_screen_space()
+{
+	// Inverse of to_screen_space: diag(1, ratio, 1, 1)
+	return mat4(
+		1, 0,    0, 0,
+		0, ratio,0, 0,
+		0, 0,    1, 0,
+		0, 0,    0, 1
+	);
+}
 
 // Always has this shape:
 // 
@@ -130,11 +142,11 @@ bool is_hidden_end()
 void _draw_segment(vec4 p, vec4 perp, float thickness)
 {
 	gl_Position = p + perp * (EDGE_OFFSET + thickness * EDGE_OFFSET_VARIANCE) * p.w;
-	gl_Position = from_screen_space * gl_Position;
+	gl_Position = from_screen_space() * gl_Position;
 	EmitVertex();
 
 	gl_Position = p - perp * (EDGE_OFFSET + thickness * EDGE_OFFSET_VARIANCE) * p.w;
-	gl_Position = from_screen_space * gl_Position;
+	gl_Position = from_screen_space() * gl_Position;
 	EmitVertex();
 }
 
@@ -143,11 +155,11 @@ void _draw_start_endcap(vec4 p, vec4 perp)
 	vec4 para = vec4(perp.y, -perp.x, 0.0f, 0.0f);
 
 	gl_Position = p - para * EDGE_OFFSET * 0.66f * p.w + perp * EDGE_OFFSET / 2 * p.w;
-	gl_Position = from_screen_space * gl_Position;
+	gl_Position = from_screen_space() * gl_Position;
 	EmitVertex();
 	
 	gl_Position = p - para * EDGE_OFFSET * 0.66f * p.w - perp * EDGE_OFFSET / 2 * p.w;
-	gl_Position = from_screen_space * gl_Position;
+	gl_Position = from_screen_space() * gl_Position;
 	EmitVertex();
 }
 
@@ -156,11 +168,11 @@ void _draw_end_endcap(vec4 p, vec4 perp)
 	vec4 para = vec4(perp.y, -perp.x, 0.0f, 0.0f);
 
 	gl_Position = p + para * EDGE_OFFSET * 0.66f * p.w + perp * EDGE_OFFSET / 2 * p.w;
-	gl_Position = from_screen_space * gl_Position;
+	gl_Position = from_screen_space() * gl_Position;
 	EmitVertex();
 	
 	gl_Position = p + para * EDGE_OFFSET * 0.66f * p.w - perp * EDGE_OFFSET / 2 * p.w;
-	gl_Position = from_screen_space * gl_Position;
+	gl_Position = from_screen_space() * gl_Position;
 	EmitVertex();
 }
 
@@ -195,8 +207,8 @@ float transform1(float v)
 
 void draw_segment(vec4 p1, vec4 p2)
 {
-	p1 = to_screen_space * p1;
-	p2 = to_screen_space * p2;
+	p1 = to_screen_space() * p1;
+	p2 = to_screen_space() * p2;
 
 	vec4 perp = normalize(vec4(p1.y / p1.w - p2.y / p2.w, p2.x / p2.w - p1.x / p1.w, 0.0f, 0.0f));
 	
@@ -227,7 +239,7 @@ void draw_segment(vec4 p1, vec4 p2)
 	vec4 totalBurst = vec4(0, 0, 0, 0);
 	for (int i = 0; i < burst_count; ++i)
 	{
-		vec4 burstPosition = to_screen_space * projection * view * vec4(burst_locations[i], 1.0f);
+		vec4 burstPosition = to_screen_space() * projection * view * vec4(burst_locations[i], 1.0f);
 		vec2 burstDirection = center.xy / center.w - burstPosition.xy / burstPosition.w;
 		float burstDistance = length(burstDirection) * burstPosition.w;
 		if (burstDistance < burst_ranges[i])

--- a/exploration/utilities/narray/operators.hpp
+++ b/exploration/utilities/narray/operators.hpp
@@ -1280,7 +1280,7 @@ wilt::NArray<typename wilt::add_ret<T, U>::type, N> operator+ (const wilt::NArra
 template <class T, class U, dim_t N>
 wilt::NArray<typename wilt::add_ret<T, U>::type, N> operator+ (wilt::NArray<T, N>&& lhs, const wilt::NArray<U, N>& rhs)
 {
-  return wilt::add<typename wilt::add_ret<T, U>::type>(std::forward<NArray<T, N>>(lhs), rhs);
+  return wilt::add<typename wilt::add_ret<T, U>::type>(std::forward<wilt::NArray<T, N>>(lhs), rhs);
 }
 template <class T, class U, dim_t N>
 wilt::NArray<typename wilt::add_ret<T, U>::type, N> operator+ (const wilt::NArray<T, N>& lhs, wilt::NArray<U, N>&& rhs)


### PR DESCRIPTION
- Updated the depth fragment shader to use explicit output variable `FragColor` instead of deprecated `gl_FragColor`.
- Refactored the line geometry shader to encapsulate screen space transformations in functions `to_screen_space()` and `from_screen_space()`, improving readability and maintainability.
- Corrected the usage of `std::forward` in NArray operator overloads to ensure proper type forwarding.